### PR TITLE
Fix importing on Linux for inconsistently named MDL/VTX/VVD files

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -3,3 +3,23 @@ def get_class_var_name(class_, var):
     for k, v in a.items():
         if id(getattr(class_, k)) == id(var) and v == var:
             return k
+
+
+def case_insensitive_file_resolution(self, path):
+    '''
+    There are a lot of cases where the .mdl file is lowercase whereas
+    the .vvd/vtx files are mixed case. Resolving the file based on the
+    same file name will work fine on case-insensitive
+    operating systems (Windows 🤮) but on Linux (and some specific macOS
+    installations) we need to work around this behavior by walking through
+    the files in the directory and do a lowercase comparison on
+    all the files in there.
+    '''
+    import os
+    directory = os.path.dirname(path)
+    filename = os.path.basename(path)
+    for root, dirs, files in os.walk(directory, topdown=False):
+        for name in files:
+            if filename.lower() == name.lower():
+                print(os.path.join(root, name))
+                return os.path.join(root, name)

--- a/VTX.py
+++ b/VTX.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from pprint import pprint
 
 def split(array, n=3):
@@ -8,16 +9,24 @@ def split(array, n=3):
 try:
     from .ByteIO import ByteIO
     from .VTX_DATA import *
+    from .Utils import case_insensitive_file_resolution
 except Exception:
     from ByteIO import ByteIO
     from VTX_DATA import *
+    from Utils import case_insensitive_file_resolution
 
 
 class SourceVtxFile49:
     def __init__(self, path=None, file=None):
         self.final = False
         if path:
-            self.reader = ByteIO(path=path + ".dx90.vtx")
+            full_path = path + ".dx90.vtx"
+            if not os.path.isfile(full_path):
+                full_path = case_insensitive_file_resolution(full_path)
+                if full_path is None:
+                    raise NotImplementedError('VTX file could not be found')
+
+            self.reader = ByteIO(path=full_path)
         elif file:
             self.reader = file
         # print('Reading VTX file')

--- a/VVD.py
+++ b/VVD.py
@@ -1,21 +1,42 @@
 import sys
+import os
 
 try:
     from .ByteIO import ByteIO
     from .VVD_DATA import SourceVvdFileData
+    from .Utils import case_insensitive_file_resolution
 except Exception:
     from ByteIO import ByteIO
     from VVD_DATA import SourceVvdFileData
+    from Utils import case_insensitive_file_resolution
 
 
 class SourceVvdFile49:
     def __init__(self, path=None, file=None):
         if path:
-            self.reader = ByteIO(path=path + ".vvd")
+            full_path = path + ".vvd"
+            if not os.path.isfile(full_path):
+                full_path = case_insensitive_file_resolution(full_path)
+                if full_path is None:
+                    raise NotImplementedError('VVD file could not be found')
+
+            self.reader = ByteIO(path=full_path)
         elif file:
             self.reader = file
         self.file_data = SourceVvdFileData()
         self.file_data.read(self.reader)
+
+    def get_full_path(self, path):
+        return path + ".vvd"
+
+    def case_insensitive_file_resolution(self, path):
+        directory = os.path.dirname(path)
+        filename = os.path.basename(path)
+        for root, dirs, files in os.walk(directory, topdown=False):
+            for name in files:
+                if filename.lower() == name.lower():
+                    print(os.path.join(root, name))
+                    return os.path.join(root, name)
 
     def test(self):
         for v in self.file_data.vertexes:

--- a/io_Mdl.py
+++ b/io_Mdl.py
@@ -189,7 +189,6 @@ class IOMdl:
             for i in range(3):
                 rand_col.append(random.uniform(.4, 1))
             try:
-               
                 mat.diffuse_color = rand_col
             except:
                 rand_col.append(1.0)
@@ -502,7 +501,7 @@ class IOMdl:
             bone = self.armature.bones.get(self.MDL.file_data.bones[attachment.localBoneIndex].name)
 
             empty = bpy.data.objects.new("empty", None)
-            bpy.context.scene.objects.link(empty)
+            #bpy.context.scene.objects.link(empty)
             empty.name = attachment.name
             pos = Vector([attachment.pos.x, attachment.pos.y, attachment.pos.z])
             rot = Euler([attachment.rot.x, attachment.rot.y, attachment.rot.z])


### PR DESCRIPTION
I ran into an import issue when attempting to import certain models on Linux. The files are named `LaraCroftTacticalClothes.dx90.vtx` and `laracrofttacticalclothes.mdl`. On Windows this would not cause a problem because Windows filesystems are case-insensitive. However, on Linux, case-sensitivity matters, which results in an import error.

The script resolves the filename based on the `basename` of the `.mdl` file. In this case it is looking for `laracrofttacticalclothes.dx90.vtx`, but the actual filename is `LaraCroftTacticalClothes.dx90.vtx`.

This pull request attempts to resolve the proper filename by iterating over the files in the .mdl directory if the right path can not be found.